### PR TITLE
Fix audio silence on Android Firefox

### DIFF
--- a/src/audioEngine.ts
+++ b/src/audioEngine.ts
@@ -149,7 +149,15 @@ export class AudioEngine {
   }
 
   async start({ tab }: { tab: string }) {
-    // Ensure AudioContext is resumed before we schedule anything.
+    // Always resume the AudioContext directly from the user gesture (the Start
+    // button click). On Android Firefox the context can re-suspend after a page
+    // visibility change, and Firefox's user-gesture token is less reliably
+    // propagated through nested async chains than in Chrome/Safari. Calling
+    // Tone.start() here guarantees we resume from the most direct gesture
+    // possible. It is idempotent: a no-op when the context is already running.
+    await Tone.start();
+
+    // Finish any remaining prewarm work (sample loading, lookAhead config).
     await this.prewarm();
 
     this.loops.forEach((loop) => loop.dispose());


### PR DESCRIPTION
On Android Firefox, the Web Audio API `AudioContext` can be left suspended for two reasons:

**1. Re-suspension after page visibility changes**
Android Firefox aggressively suspends the context when the page loses focus (screen lock, app switching). Since `hasPrewarmed` stays `true` after the first prewarm, subsequent `start()` calls skip `Tone.start()` inside `prewarm()` and never call `AudioContext.resume()` again.

**2. Indirect user-gesture token propagation**
The `pointerdown` prewarm calls `Tone.start()` through nested async IIFEs. Android Firefox is stricter than Chrome/Safari about accepting `AudioContext.resume()` calls arriving this indirectly from a user gesture, and may silently ignore the resume attempt.

**Fix:** Call `Tone.start()` unconditionally at the top of `start()`, which is invoked directly from the Start button click — a clear user gesture every browser accepts. `Tone.start()` is idempotent (no-op when the context is already running), so this is always safe.

https://claude.ai/code/session_01BaG794n2tZ2WWKYJqCXvN6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaG794n2tZ2WWKYJqCXvN6)_